### PR TITLE
Initial implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 
 # Module directory
 .terraform/
+.idea
+*.iml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+addons:
+  apt:
+    packages:
+      - git
+      - make
+      - curl
+
+install:
+  - make init
+
+script:
+  - make terraform/install
+  - make terraform/get-plugins
+  - make terraform/get-modules
+  - make terraform/lint
+  - make terraform/validate

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2018 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+SHELL := /bin/bash
+
+-include $(shell curl -sSL -o .build-harness "https://git.io/build-harness"; echo .build-harness)
+
+lint:
+	$(SELF) terraform/install terraform/get-modules terraform/get-plugins terraform/lint terraform/validate

--- a/README.md
+++ b/README.md
@@ -1,2 +1,140 @@
-# terraform-aws-kops-external-dns
-Terraform module to provision an IAM role for external-dns
+# terraform-aws-kops-external-dns [![Build Status](https://travis-ci.org/cloudposse/terraform-aws-kops-external-dns.svg?branch=master)](https://travis-ci.org/cloudposse/terraform-aws-kops-external-dns)
+
+Terraform module to provision an IAM role for `external-dns` running in a Kops cluster, and attach an IAM policy to the role with permissions to modify Route53 record sets.
+
+
+## Overview
+
+This module assumes you are running [external-dns](https://github.com/kubernetes-incubator/external-dns) in a Kops cluster.
+
+It will provision an IAM role with the required permissions and grant the k8s masters the permission to assume it.
+
+This is useful to make Kubernetes services discoverable via AWS DNS services.
+
+The module uses [terraform-aws-kops-metadata](https://github.com/cloudposse/terraform-aws-kops-metadata) to lookup resources within a Kops cluster for easier integration with Terraform.
+
+
+## Usage
+
+```hcl
+module "kops_external_dns" {
+  source       = "git::https://github.com/cloudposse/terraform-aws-kops-external-dns.git?ref=master"
+  namespace    = "cp"
+  stage        = "prod"
+  name         = "domain.com"
+  masters_name = "masters"
+
+  tags = {
+    Cluster = "k8s.domain.com"
+  }
+}
+```
+
+
+## Variables
+
+|  Name              |  Default     |  Description                                                                     | Required |
+|:-------------------|:-------------|:---------------------------------------------------------------------------------|:--------:|
+| `namespace`        | ``           | Namespace (_e.g._ `cp` or `cloudposse`)                                          | Yes      |
+| `stage`            | ``           | Stage (_e.g._ `prod`, `dev`, `staging`)                                          | Yes      |
+| `name`             | ``           | Name of the Kops DNS zone (e.g. `domain.com`)                                    | Yes      |
+| `attributes`       | `[]`         | Additional attributes (_e.g._ `policy` or `role`)                                | No       |
+| `tags`             | `{}`         | Additional tags  (_e.g._ `map("Cluster","k8s.domain.com")`                       | No       |
+| `delimiter`        | `-`          | Delimiter to be used between `namespace`, `stage`, `name`, and `attributes`      | No       |
+| `masters_name`     | `masters`    | k8s masters subdomain name in the Kops DNS zone                                  | No       |
+
+
+## Outputs
+
+| Name               | Description          |
+|:-------------------|:---------------------|
+| `role_name`        | IAM role name        |
+| `role_unique_id`   | IAM role unique ID   |
+| `role_arn`         | IAM role ARN         |
+| `policy_name`      | IAM policy name      |
+| `policy_id`        | IAM policy ID        |
+| `policy_arn`       | IAM policy ARN       |
+
+
+## Help
+
+**Got a question?**
+
+File a GitHub [issue](https://github.com/cloudposse/terraform-aws-kops-external-dns/issues), send us an [email](mailto:hello@cloudposse.com) or reach out to us on [Gitter](https://gitter.im/cloudposse/).
+
+
+## Contributing
+
+### Bug Reports & Feature Requests
+
+Please use the [issue tracker](https://github.com/cloudposse/terraform-aws-kops-external-dns/issues) to report any bugs or file feature requests.
+
+### Developing
+
+If you are interested in being a contributor and want to get involved in developing `terraform-aws-kops-external-dns`, we would love to hear from you! Shoot us an [email](mailto:hello@cloudposse.com).
+
+In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
+
+ 1. **Fork** the repo on GitHub
+ 2. **Clone** the project to your own machine
+ 3. **Commit** changes to your own branch
+ 4. **Push** your work back up to your fork
+ 5. Submit a **Pull request** so that we can review your changes
+
+**NOTE:** Be sure to merge the latest from "upstream" before making a pull request!
+
+
+## License
+
+[APACHE 2.0](LICENSE) © 2018 [Cloud Posse, LLC](https://cloudposse.com)
+
+See [LICENSE](LICENSE) for full details.
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+## About
+
+`terraform-aws-kops-external-dns` is maintained and funded by [Cloud Posse, LLC][website].
+
+![Cloud Posse](https://cloudposse.com/logo-300x69.png)
+
+
+Like it? Please let us know at <hello@cloudposse.com>
+
+We love [Open Source Software](https://github.com/cloudposse/)!
+
+See [our other projects][community]
+or [hire us][hire] to help build your next cloud platform.
+
+  [website]: https://cloudposse.com/
+  [community]: https://github.com/cloudposse/
+  [hire]: https://cloudposse.com/contact/
+
+
+## Contributors
+
+| [![Erik Osterman][erik_img]][erik_web]<br/>[Erik Osterman][erik_web] | [![Andriy Knysh][andriy_img]][andriy_web]<br/>[Andriy Knysh][andriy_web] |[![Igor Rodionov][igor_img]][igor_web]<br/>[Igor Rodionov][igor_img]
+|-------------------------------------------------------|------------------------------------------------------------------|------------------------------------------------------------------|
+
+[erik_img]: http://s.gravatar.com/avatar/88c480d4f73b813904e00a5695a454cb?s=144
+[erik_web]: https://github.com/osterman/
+[andriy_img]: https://avatars0.githubusercontent.com/u/7356997?v=4&u=ed9ce1c9151d552d985bdf5546772e14ef7ab617&s=144
+[andriy_web]: https://github.com/aknysh/
+[igor_img]: http://s.gravatar.com/avatar/bc70834d32ed4517568a1feb0b9be7e2?s=144
+[igor_web]: https://github.com/goruha/

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,97 @@
+module "label" {
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.3"
+  namespace  = "${var.namespace}"
+  stage      = "${var.stage}"
+  name       = "${var.name}"
+  delimiter  = "${var.delimiter}"
+  attributes = "${var.attributes}"
+  tags       = "${var.tags}"
+}
+
+module "kops_metadata" {
+  source       = "git::https://github.com/cloudposse/terraform-aws-kops-metadata.git?ref=tags/0.1.1"
+  dns_zone     = "${var.name}"
+  masters_name = "${var.masters_name}"
+}
+
+resource "aws_iam_role" "default" {
+  name        = "${module.label.id}"
+  description = "Role that can be assumed by external-dns"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+
+    principals {
+      type        = "AWS"
+      identifiers = ["${module.kops_metadata.masters_role_arn}"]
+    }
+
+    effect = "Allow"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "default" {
+  role       = "${aws_iam_role.default.name}"
+  policy_arn = "${aws_iam_policy.default.arn}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_iam_policy" "default" {
+  name        = "${module.label.id}"
+  description = "Grant permissions for external-dns"
+  policy      = "${data.aws_iam_policy_document.default.json}"
+}
+
+data "aws_route53_zone" "default" {
+  name         = "${var.name}."
+  private_zone = false
+}
+
+data "aws_iam_policy_document" "default" {
+  statement {
+    sid = "GrantModifyAccessToDomains"
+
+    actions = [
+      "route53:ChangeResourceRecordSets",
+    ]
+
+    effect = "Allow"
+
+    resources = [
+      "arn:aws:route53:::hostedzone/${data.aws_route53_zone.default.zone_id}",
+    ]
+  }
+
+  statement {
+    sid = "GrantListAccessToDomains"
+
+    actions = [
+      "route53:ListHostedZones",
+      "route53:ListResourceRecordSets",
+    ]
+
+    effect = "Allow"
+
+    resources = [
+      "*",
+    ]
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,23 @@
+output "role_name" {
+  value = "${aws_iam_role.default.name}"
+}
+
+output "role_unique_id" {
+  value = "${aws_iam_role.default.unique_id}"
+}
+
+output "role_arn" {
+  value = "${aws_iam_role.default.arn}"
+}
+
+output "policy_name" {
+  value = "${aws_iam_policy.default.name}"
+}
+
+output "policy_id" {
+  value = "${aws_iam_policy.default.id}"
+}
+
+output "policy_arn" {
+  value = "${aws_iam_policy.default.arn}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,38 @@
+variable "namespace" {
+  type        = "string"
+  description = "Namespace (e.g. `cp` or `cloudposse`)"
+}
+
+variable "stage" {
+  type        = "string"
+  description = "Stage (e.g. `prod`, `dev`, `staging`)"
+}
+
+variable "name" {
+  type        = "string"
+  description = "Name of the Kops DNS zone (e.g. `domain.com`)"
+}
+
+variable "delimiter" {
+  type        = "string"
+  default     = "-"
+  description = "Delimiter to be used between `namespace`, `stage`, `name`, and `attributes`"
+}
+
+variable "attributes" {
+  type        = "list"
+  default     = []
+  description = "Additional attributes (e.g. `policy` or `role`)"
+}
+
+variable "tags" {
+  type        = "map"
+  default     = {}
+  description = "Additional tags (e.g. map(`Cluster`,`k8s.domain.com`)"
+}
+
+variable "masters_name" {
+  type        = "string"
+  default     = "masters"
+  description = "k8s masters subdomain name in the Kops DNS zone"
+}


### PR DESCRIPTION
## what
* Terraform module to provision an IAM role for `external-dns` with the required permissions to modify Route53 record sets

## why
* Make it easier to provision resources required for `external-dns` running in a Kops cluster
* Useful to make Kubernetes services discoverable via AWS DNS services
