### PR TITLE
Separate `cluster_name` and `name` variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Terraform module to provision an IAM role for `external-dns` running in a Kops c
 
 This module assumes you are running [external-dns](https://github.com/kubernetes-incubator/external-dns) in a Kops cluster.
 
-It will provision an IAM role with the required permissions and grant the k8s masters the permission to assume it.
+It will provision an IAM role with the required permissions and grant the Kops masters the permission to assume it.
 
 This is useful to make Kubernetes services discoverable via AWS DNS services.
 
@@ -21,11 +21,12 @@ module "kops_external_dns" {
   source       = "git::https://github.com/cloudposse/terraform-aws-kops-external-dns.git?ref=master"
   namespace    = "cp"
   stage        = "prod"
-  name         = "domain.com"
+  name         = "external-dns"
+  cluster_name = "us-east-1.cloudposse.com"
   masters_name = "masters"
 
   tags = {
-    Cluster = "k8s.domain.com"
+    Cluster = "us-east-1.cloudposse.com"
   }
 }
 ```
@@ -33,15 +34,16 @@ module "kops_external_dns" {
 
 ## Variables
 
-|  Name              |  Default     |  Description                                                                     | Required |
-|:-------------------|:-------------|:---------------------------------------------------------------------------------|:--------:|
-| `namespace`        | ``           | Namespace (_e.g._ `cp` or `cloudposse`)                                          | Yes      |
-| `stage`            | ``           | Stage (_e.g._ `prod`, `dev`, `staging`)                                          | Yes      |
-| `name`             | ``           | Name of the Kops DNS zone (e.g. `domain.com`)                                    | Yes      |
-| `attributes`       | `[]`         | Additional attributes (_e.g._ `policy` or `role`)                                | No       |
-| `tags`             | `{}`         | Additional tags  (_e.g._ `map("Cluster","k8s.domain.com")`                       | No       |
-| `delimiter`        | `-`          | Delimiter to be used between `namespace`, `stage`, `name`, and `attributes`      | No       |
-| `masters_name`     | `masters`    | k8s masters subdomain name in the Kops DNS zone                                  | No       |
+|  Name              |  Default        |  Description                                                                     | Required |
+|:-------------------|:----------------|:---------------------------------------------------------------------------------|:--------:|
+| `namespace`        | ``              | Namespace (_e.g._ `cp` or `cloudposse`)                                          | Yes      |
+| `stage`            | ``              | Stage (_e.g._ `prod`, `dev`, `staging`)                                          | Yes      |
+| `cluster_name`     | ``              | Cluater name (_e.g._ `us-east-1.cloudposse.com`)                                 | Yes      |
+| `name`             | `external-dns`  | Name (e.g. `external-dns`)                                                       | No       |
+| `attributes`       | `[]`            | Additional attributes (_e.g._ `1`)                                               | No       |
+| `tags`             | `{}`            | Additional tags  (_e.g._ `map("Cluster","us-east-1.cloudposse.com")`             | No       |
+| `delimiter`        | `-`             | Delimiter to be used between `namespace`, `stage`, `name` and `attributes`       | No       |
+| `masters_name`     | `masters`       | Kops masters subdomain name in the cluster DNS zone                              | No       |
 
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ module "label" {
 
 module "kops_metadata" {
   source       = "git::https://github.com/cloudposse/terraform-aws-kops-metadata.git?ref=tags/0.1.1"
-  dns_zone     = "${var.name}"
+  dns_zone     = "${var.cluster_name}"
   masters_name = "${var.masters_name}"
 }
 
@@ -61,7 +61,7 @@ resource "aws_iam_policy" "default" {
 }
 
 data "aws_route53_zone" "default" {
-  name         = "${var.name}."
+  name         = "${var.cluster_name}."
   private_zone = false
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -10,29 +10,35 @@ variable "stage" {
 
 variable "name" {
   type        = "string"
-  description = "Name of the Kops DNS zone (e.g. `domain.com`)"
+  default     = "external-dns"
+  description = "Name (e.g. `external-dns`)"
 }
 
 variable "delimiter" {
   type        = "string"
   default     = "-"
-  description = "Delimiter to be used between `namespace`, `stage`, `name`, and `attributes`"
+  description = "Delimiter to be used between `namespace`, `stage`, `name` and `attributes`"
 }
 
 variable "attributes" {
   type        = "list"
   default     = []
-  description = "Additional attributes (e.g. `policy` or `role`)"
+  description = "Additional attributes (e.g. `1`)"
 }
 
 variable "tags" {
   type        = "map"
   default     = {}
-  description = "Additional tags (e.g. map(`Cluster`,`k8s.domain.com`)"
+  description = "Additional tags (e.g. map(`Cluster`,`us-east-1.cloudposse.com`)"
+}
+
+variable "cluster_name" {
+  type        = "string"
+  description = "Kops cluster name (e.g. `us-east-1.cloudposse.com` or `cluster-1.cloudposse.com`)"
 }
 
 variable "masters_name" {
   type        = "string"
   default     = "masters"
-  description = "k8s masters subdomain name in the Kops DNS zone"
+  description = "Kops masters subdomain name in the cluster DNS zone"
 }


### PR DESCRIPTION
## what
* Separate `cluster_name` and `name` variables

## why
* Use `name` variable for all created resources (S3 buckets, IAM Roles, etc.)
* Use `cluster_name` as a pattern to lookup Kops clusters
