### PR TITLE
Allow nodes assume role

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ module "kops_external_dns" {
   name         = "external-dns"
   cluster_name = "us-east-1.cloudposse.com"
   masters_name = "masters"
+  nodes_name   = "nodes"  
 
   tags = {
     Cluster = "us-east-1.cloudposse.com"
@@ -44,6 +45,7 @@ module "kops_external_dns" {
 | `tags`             | `{}`            | Additional tags  (_e.g._ `map("Cluster","us-east-1.cloudposse.com")`             | No       |
 | `delimiter`        | `-`             | Delimiter to be used between `namespace`, `stage`, `name` and `attributes`       | No       |
 | `masters_name`     | `masters`       | Kops masters subdomain name in the cluster DNS zone                              | No       |
+| `nodes_name`       | `nodes`         | Kops nodes subdomain name in the cluster DNS zone                                | No       |
 
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,7 @@ module "kops_metadata" {
   source       = "git::https://github.com/cloudposse/terraform-aws-kops-metadata.git?ref=tags/0.1.1"
   dns_zone     = "${var.cluster_name}"
   masters_name = "${var.masters_name}"
+  nodes_name   = "${var.nodes_name}"
 }
 
 resource "aws_iam_role" "default" {
@@ -38,7 +39,10 @@ data "aws_iam_policy_document" "assume_role" {
 
     principals {
       type        = "AWS"
-      identifiers = ["${module.kops_metadata.masters_role_arn}"]
+      identifiers = [
+        "${module.kops_metadata.masters_role_arn}",
+        "${module.kops_metadata.nodes_role_arn}"
+      ]
     }
 
     effect = "Allow"

--- a/variables.tf
+++ b/variables.tf
@@ -42,3 +42,10 @@ variable "masters_name" {
   default     = "masters"
   description = "Kops masters subdomain name in the cluster DNS zone"
 }
+
+variable "nodes_name" {
+  type        = "string"
+  default     = "nodes"
+  description = "Kops nodes subdomain name in the cluster DNS zone"
+}
+


### PR DESCRIPTION
## What
* Allow assuming the role on nodes

## Why
* `External DNS` works nicely with `assumed roles` so we can run it on nodes (instead of masters only)