### PR TITLE
Specify list of dns zone names to manage (breaking change)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,14 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 
 ```hcl
 module "kops_external_dns" {
-  source       = "git::https://github.com/cloudposse/terraform-aws-kops-external-dns.git?ref=master"
-  namespace    = "cp"
-  stage        = "prod"
-  name         = "external-dns"
-  cluster_name = "us-east-1.cloudposse.com"
-  masters_name = "masters"
-  nodes_name   = "nodes"  
+  source         = "git::https://github.com/cloudposse/terraform-aws-kops-external-dns.git?ref=master"
+  namespace      = "cp"
+  stage          = "prod"
+  name           = "external-dns"
+  cluster_name   = "us-east-1.cloudposse.com"
+  dns_zone_names = ["us-east-1.cloudposse.com", "cloudposse.com"]
+  masters_name   = "masters"
+  nodes_name     = "nodes"
 
   tags = {
     Cluster = "us-east-1.cloudposse.com"
@@ -84,7 +85,6 @@ Available targets:
   lint                                Lint terraform code
 
 ```
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -92,6 +92,7 @@ Available targets:
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
 | cluster_name | Kops cluster name (e.g. `us-east-1.cloudposse.com` or `cluster-1.cloudposse.com`) | string | - | yes |
 | delimiter | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | string | `-` | no |
+| dns_zone_names | Names of zones to manage (e.g. `us-east-1.cloudposse.com` or `cluster-1.cloudposse.com`) | list | - | yes |
 | masters_name | Kops masters subdomain name in the cluster DNS zone | string | `masters` | no |
 | name | Name (e.g. `external-dns`) | string | `external-dns` | no |
 | namespace | Namespace (e.g. `cp` or `cloudposse`) | string | - | yes |
@@ -196,7 +197,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2018 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2019 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/README.md
+++ b/README.md
@@ -55,17 +55,17 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 
 ```hcl
 module "kops_external_dns" {
-  source         = "git::https://github.com/cloudposse/terraform-aws-kops-external-dns.git?ref=master"
+  source         = "git::https://github.com/cloudposse/terraform-aws-kops-external-dns.git?ref=tags/<release-tag>"
   namespace      = "cp"
   stage          = "prod"
   name           = "external-dns"
-  cluster_name   = "us-east-1.cloudposse.com"
-  dns_zone_names = ["us-east-1.cloudposse.com", "cloudposse.com"]
+  cluster_name   = "us-east-1.cloudposse.co"
+  dns_zone_names = ["us-east-1.cloudposse.co", "cloudposse.co"]
   masters_name   = "masters"
   nodes_name     = "nodes"
 
   tags = {
-    Cluster = "us-east-1.cloudposse.com"
+    Cluster = "us-east-1.cloudposse.co"
   }
 }
 ```
@@ -90,15 +90,15 @@ Available targets:
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
-| cluster_name | Kops cluster name (e.g. `us-east-1.cloudposse.com` or `cluster-1.cloudposse.com`) | string | - | yes |
+| cluster_name | Kops cluster name (e.g. `us-east-1.cloudposse.co` or `cluster-1.cloudposse.co`) | string | - | yes |
 | delimiter | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | string | `-` | no |
-| dns_zone_names | Names of zones to manage (e.g. `us-east-1.cloudposse.com` or `cluster-1.cloudposse.com`) | list | - | yes |
+| dns_zone_names | Names of zones to manage (e.g. `us-east-1.cloudposse.co` or `cluster-1.cloudposse.co`) | list | - | yes |
 | masters_name | Kops masters subdomain name in the cluster DNS zone | string | `masters` | no |
 | name | Name (e.g. `external-dns`) | string | `external-dns` | no |
 | namespace | Namespace (e.g. `cp` or `cloudposse`) | string | - | yes |
 | nodes_name | Kops nodes subdomain name in the cluster DNS zone | string | `nodes` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | - | yes |
-| tags | Additional tags (e.g. map(`Cluster`,`us-east-1.cloudposse.com`) | map | `<map>` | no |
+| tags | Additional tags (e.g. map(`Cluster`,`us-east-1.cloudposse.co`) | map | `<map>` | no |
 
 ## Outputs
 

--- a/README.yaml
+++ b/README.yaml
@@ -88,13 +88,14 @@ description: |-
 usage: |-
   ```hcl
   module "kops_external_dns" {
-    source       = "git::https://github.com/cloudposse/terraform-aws-kops-external-dns.git?ref=master"
-    namespace    = "cp"
-    stage        = "prod"
-    name         = "external-dns"
-    cluster_name = "us-east-1.cloudposse.com"
-    masters_name = "masters"
-    nodes_name   = "nodes"  
+    source         = "git::https://github.com/cloudposse/terraform-aws-kops-external-dns.git?ref=master"
+    namespace      = "cp"
+    stage          = "prod"
+    name           = "external-dns"
+    cluster_name   = "us-east-1.cloudposse.com"
+    dns_zone_names = ["us-east-1.cloudposse.com", "cloudposse.com"]
+    masters_name   = "masters"
+    nodes_name     = "nodes"
 
     tags = {
       Cluster = "us-east-1.cloudposse.com"

--- a/README.yaml
+++ b/README.yaml
@@ -88,17 +88,17 @@ description: |-
 usage: |-
   ```hcl
   module "kops_external_dns" {
-    source         = "git::https://github.com/cloudposse/terraform-aws-kops-external-dns.git?ref=master"
+    source         = "git::https://github.com/cloudposse/terraform-aws-kops-external-dns.git?ref=tags/<release-tag>"
     namespace      = "cp"
     stage          = "prod"
     name           = "external-dns"
-    cluster_name   = "us-east-1.cloudposse.com"
-    dns_zone_names = ["us-east-1.cloudposse.com", "cloudposse.com"]
+    cluster_name   = "us-east-1.cloudposse.co"
+    dns_zone_names = ["us-east-1.cloudposse.co", "cloudposse.co"]
     masters_name   = "masters"
     nodes_name     = "nodes"
 
     tags = {
-      Cluster = "us-east-1.cloudposse.com"
+      Cluster = "us-east-1.cloudposse.co"
     }
   }
   ```

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,15 +3,15 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
-| cluster_name | Kops cluster name (e.g. `us-east-1.cloudposse.com` or `cluster-1.cloudposse.com`) | string | - | yes |
+| cluster_name | Kops cluster name (e.g. `us-east-1.cloudposse.co` or `cluster-1.cloudposse.co`) | string | - | yes |
 | delimiter | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | string | `-` | no |
-| dns_zone_names | Names of zones to manage (e.g. `us-east-1.cloudposse.com` or `cluster-1.cloudposse.com`) | list | - | yes |
+| dns_zone_names | Names of zones to manage (e.g. `us-east-1.cloudposse.co` or `cluster-1.cloudposse.co`) | list | - | yes |
 | masters_name | Kops masters subdomain name in the cluster DNS zone | string | `masters` | no |
 | name | Name (e.g. `external-dns`) | string | `external-dns` | no |
 | namespace | Namespace (e.g. `cp` or `cloudposse`) | string | - | yes |
 | nodes_name | Kops nodes subdomain name in the cluster DNS zone | string | `nodes` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | - | yes |
-| tags | Additional tags (e.g. map(`Cluster`,`us-east-1.cloudposse.com`) | map | `<map>` | no |
+| tags | Additional tags (e.g. map(`Cluster`,`us-east-1.cloudposse.co`) | map | `<map>` | no |
 
 ## Outputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,4 +1,3 @@
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -6,6 +5,7 @@
 | attributes | Additional attributes (e.g. `1`) | list | `<list>` | no |
 | cluster_name | Kops cluster name (e.g. `us-east-1.cloudposse.com` or `cluster-1.cloudposse.com`) | string | - | yes |
 | delimiter | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | string | `-` | no |
+| dns_zone_names | Names of zones to manage (e.g. `us-east-1.cloudposse.com` or `cluster-1.cloudposse.com`) | list | - | yes |
 | masters_name | Kops masters subdomain name in the cluster DNS zone | string | `masters` | no |
 | name | Name (e.g. `external-dns`) | string | `external-dns` | no |
 | namespace | Namespace (e.g. `cp` or `cloudposse`) | string | - | yes |

--- a/main.tf
+++ b/main.tf
@@ -66,7 +66,8 @@ resource "aws_iam_policy" "default" {
 }
 
 data "aws_route53_zone" "default" {
-  name         = "${var.cluster_name}."
+  count        = "${length(var.dns_zone_names)}"
+  name         = "${element(var.dns_zone_names, count.index)}."
   private_zone = false
 }
 
@@ -81,7 +82,7 @@ data "aws_iam_policy_document" "default" {
     effect = "Allow"
 
     resources = [
-      "arn:aws:route53:::hostedzone/${data.aws_route53_zone.default.zone_id}",
+      "${formatlist("arn:aws:route53:::hostedzone/%s", data.aws_route53_zone.default.*.zone_id)}",
     ]
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -29,17 +29,17 @@ variable "attributes" {
 variable "tags" {
   type        = "map"
   default     = {}
-  description = "Additional tags (e.g. map(`Cluster`,`us-east-1.cloudposse.com`)"
+  description = "Additional tags (e.g. map(`Cluster`,`us-east-1.cloudposse.co`)"
 }
 
 variable "cluster_name" {
   type        = "string"
-  description = "Kops cluster name (e.g. `us-east-1.cloudposse.com` or `cluster-1.cloudposse.com`)"
+  description = "Kops cluster name (e.g. `us-east-1.cloudposse.co` or `cluster-1.cloudposse.co`)"
 }
 
 variable "dns_zone_names" {
   type        = "list"
-  description = "Names of zones to manage (e.g. `us-east-1.cloudposse.com` or `cluster-1.cloudposse.com`)"
+  description = "Names of zones to manage (e.g. `us-east-1.cloudposse.co` or `cluster-1.cloudposse.co`)"
 }
 
 variable "masters_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -37,6 +37,11 @@ variable "cluster_name" {
   description = "Kops cluster name (e.g. `us-east-1.cloudposse.com` or `cluster-1.cloudposse.com`)"
 }
 
+variable "dns_zone_names" {
+  type        = "list"
+  description = "Names of zones to manage (e.g. `us-east-1.cloudposse.com` or `cluster-1.cloudposse.com`)"
+}
+
 variable "masters_name" {
   type        = "string"
   default     = "masters"


### PR DESCRIPTION
## what
Require an explicit list of DNS zones to manage.

Previously, external-dns was limited to managing the DNS zone corresponding to the cluster name, and managed that by default. This change allows it to manage DNS zone outside of the cluster name, and requires that zones be explicitly enabled.

## why
Necessary additional control over scope of DNS management.