### PR TITLE
Expand permissions for cert-manager

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -87,15 +87,28 @@ data "aws_iam_policy_document" "default" {
   statement {
     sid = "GrantListAccessToDomains"
 
+    # route53:ListHostedZonesByName is not needed by external-dns, but is needed by cert-manager
     actions = [
       "route53:ListHostedZones",
+      "route53:ListHostedZonesByName",
       "route53:ListResourceRecordSets",
     ]
 
     effect = "Allow"
 
-    resources = [
-      "*",
+    resources = ["*"]
+  }
+
+  # route53:GetChange is not needed by external-dns, but is needed by cert-manager
+  statement {
+    sid = "GrantGetChangeStatus"
+
+    actions = [
+      "route53:GetChange",
     ]
+
+    effect = "Allow"
+
+    resources = ["arn:aws:route53:::change/*"]
   }
 }


### PR DESCRIPTION
## what
Expand IAM permissions so [cert-manager](https://docs.cert-manager.io/) can also use this role
## why
`cert-manager` needs the same kind of permissions so that it can create fake domain names to prove it controls the domain names to get TLS certificates issued. It seems better to reuse this role than to try to maintain 2 roles in parallel. 